### PR TITLE
addJFont.sty: support scale option

### DIFF
--- a/sty/addJFont.sty
+++ b/sty/addJFont.sty
@@ -1,9 +1,16 @@
 \NeedsTeXFormat{pLaTeX2e}
 \ProvidesPackage{addJFont}[2016/12/06 v0.1 doraTeX]
+\RequirePackage{keyval}
 
 \newif\ifaddJFont@uplatex \addJFont@uplatexfalse
 
 \DeclareOption{uplatex}{\addJFont@uplatextrue}
+
+\DeclareOption*{\addJFont@setkey}
+\def\addJFont@setkey{\expandafter\addJFont@setkey@x\expandafter{\CurrentOption}}
+\def\addJFont@setkey@x{\setkeys{addJFont}}
+
+\define@key{addJFont}{scale}{\def\addJFont@given@scale{#1}}
 \ProcessOptions\relax
 
 \ifaddJFont@uplatex
@@ -13,6 +20,10 @@
   \def\addJFont@scale{0.961000}%%% scale for jis.tfm
   \def\addJFontEnc{1}
 \fi
+\@ifundefined{addJFont@given@scale}{}{%
+  \edef\addJFont@scale{\addJFont@given@scale}%
+}
+
 
 \@onlypreamble\addJFont@special
 \let\addJFont@special\@empty


### PR DESCRIPTION
@doraTeX さん、
汎用クラスファイル jclasses, jsclasses で利用する範囲では、件名のscaleオプションは不要ですけれども、「10 pt を13級に割り当てる」（以下の例）などなどやる場合に、あったほうがよいと思い、このPRをいたしました。
寺田さんがscaleオプションを不要と判断されれば、それでもかまいません :D 

```latex
%#!ptex2pdf -l -u
\documentclass{ujarticle}
\usepackage[scale=0.924714]{addJFont}
\begin{document}
13\,\textbackslash JQ $\approx$ 10\,pt

\makeatletter
\newdimen\JQ \JQ=1.08141Q\relax
\@tempdima=13\JQ
\typeout{!!! 13JQ=\the\@tempdima}
\makeatother
\end{document}
```

